### PR TITLE
Update to work with middleman 4.0

### DIFF
--- a/lib/middleman-es6.rb
+++ b/lib/middleman-es6.rb
@@ -1,5 +1,6 @@
 require "middleman-core"
 require "middleman-es6/template"
+require "sprockets"
 
 class MiddlemanEs6Extension < ::Middleman::Extension
   def initialize(app, options_hash={}, &block)

--- a/middleman-es6.gemspec
+++ b/middleman-es6.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency("middleman-core", [">= 3.3.12"], ["< 4.0"])
+  s.add_runtime_dependency("middleman-core", [">= 3.3.12"], ["< 4.2"])
   s.add_runtime_dependency("middleman-sprockets", ["> 3.3"])
   s.add_runtime_dependency("babel-transpiler")
 end


### PR DESCRIPTION
I haven't looked into this much, but I wasn't able to use it out of the box with Middleman 4.x because of the gemspec constraint. 

This updates the version requirement to be `< 4.2` (current version is 4.1.7). 

The only other change that was needed was to `require "Sprockets"` (again, I didn't look into this very much). 

@vast 
